### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "comfyui-to-python-extension"
-description = ""
+description = "A version of ComfyUI-to-Python-Extension that works as a custom node. Adds a button in the UI that saves the current workflow as a Python file, a CLI for converting workflows, and slightly better custom node support."
 version = "1.0.0"
 license = "LICENSE"
 dependencies = ["torch", "torchdiffeq", "torchsde", "einops", "transformers>=4.25.1", "safetensors>=0.3.0", "aiohttp", "accelerate", "pyyaml", "Pillow", "scipy", "tqdm", "black"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "comfyui-to-python-extension"
+description = ""
+version = "1.0.0"
+license = "LICENSE"
+dependencies = ["torch", "torchdiffeq", "torchsde", "einops", "transformers>=4.25.1", "safetensors>=0.3.0", "aiohttp", "accelerate", "pyyaml", "Pillow", "scipy", "tqdm", "black"]
+
+[project.urls]
+Repository = "https://github.com/pydn/ComfyUI-to-Python-Extension"
+#  Used by Comfy Registry https://comfyregistry.org
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "ComfyUI-to-Python-Extension"
+Icon = ""


### PR DESCRIPTION
We are building a global registry for custom nodes (similar to PyPI). The registry makes using custom nodes more reliable by reserving globally unique names for each custom node, and supporting semantic versioning.

Here’s some [more information](https://www.comfydocs.org/registry/overview#introduction) on the registry.

Action Required:

- [ ] Go to the [registry](https://www.comfyregistry.org/). Login and create a publisher id. Comment it here and we will update the PR (or just merge it and change it yourself).
- [ ] Write a short the description.
- [ ] Merge the separate Github Actions PR and run the workflow.
If you want to publish the node manually, [install the cli](https://www.comfydocs.org/comfy-cli/getting-started#install-cli) and run `comfy node publish`


Please message me on [Discord](https://discord.com/invite/comfycontrib) if you have any questions!