### PR TITLE
Update init based on latest comfyui

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -13,7 +13,7 @@ def import_custom_nodes() -> None:
     """
     import asyncio
     import execution
-    from nodes import init_custom_nodes
+    from nodes import init_extra_nodes
     import server
 
     # Creating a new event loop and setting it as the default loop
@@ -25,7 +25,7 @@ def import_custom_nodes() -> None:
     execution.PromptQueue(server_instance)
 
     # Initializing custom nodes
-    init_custom_nodes()
+    init_extra_nodes()
 
 
 def find_path(name: str, path: str = None) -> str:


### PR DESCRIPTION
Error that I've found.

```
Traceback (most recent call last):
  File "/home/albert/Documents/dev/ComfyUI/ComfyUI-to-Python-Extension/comfyui_to_python.py", line 460, in <module>
    ComfyUItoPython(input_file=input_file, output_file=output_file, queue_size=queue_size)
  File "/home/albert/Documents/dev/ComfyUI/ComfyUI-to-Python-Extension/comfyui_to_python.py", line 425, in __init__
    self.execute()
  File "/home/albert/Documents/dev/ComfyUI/ComfyUI-to-Python-Extension/comfyui_to_python.py", line 434, in execute
    import_custom_nodes()
  File "/home/albert/Documents/dev/ComfyUI/ComfyUI-to-Python-Extension/utils.py", line 16, in import_custom_nodes
    from nodes import init_custom_nodes
ImportError: cannot import name 'init_custom_nodes' from 'nodes' (/home/albert/Documents/dev/ComfyUI/ComfyUI-to-Python-Extension/../nodes.py). Did you mean: 'init_extra_nodes'?
```

I think the import is old. This PR updates the import.